### PR TITLE
Fix typos and clarify instructions in guides

### DIFF
--- a/guides/python_agent.qmd
+++ b/guides/python_agent.qmd
@@ -131,16 +131,16 @@ The following fields are typically used:
 period = 200
 venv = "/path/to/.venv"
 python_module = "my_source"
-search_paths = ["/path/to/python/folder"
+search_paths = ["/path/to/python/folder"]
 ```
 
 ::: callout-warning
-The section name must match the `-m` option argument when you launch the agent, so in the case aboxe you must use `-m python_source`.
+The section name must match the `-n` option argument when you launch the agent, so in the case above you must use `-n python_source`.
 :::
 
 During **development**, you typically run the plugin interactively and using a python module that is under your home folder. In these conditions, you probably want to set the module name on the command line, such as `mads python -n python_source -m my_module`. This means that you must have the file `my_module.py` in the `python` or `scripts` subfolder of your current working directory.
 
-During **deployment**, you want to transform the agent in a service, so that you rely on the module to be loaded according to the ` mads.ini` file (from the `python_module` key), and the module is expected to be placed in `<INSTALL_PREFIX>/python/my_module.py`. Since `INSTALL_PREFIX` is usually `/usr/local`, this means that the file should be in `/usr/local/python/my_module.py`. Then you create a service as documented [here](services.html).
+During **deployment**, you want to transform the agent in a service, so that you rely on the module to be loaded according to the `mads.ini` file (from the `python_module` key), and the module is expected to be placed in `<INSTALL_PREFIX>/python/my_module.py`. Since `INSTALL_PREFIX` is usually `/usr/local`, this means that the file should be in `/usr/local/python/my_module.py`. Then you create a service as documented [here](services.html).
 
 ## Module Types
 

--- a/guides/services.qmd
+++ b/guides/services.qmd
@@ -41,13 +41,13 @@ So, if the service is enabled, it starts automatically on boot; if it is disable
 
 # How to create a MADS service
 
-Suppose that you knwo that the following command launches properly an agent:
+Suppose that you know that the following command launches properly an agent:
 
 ```bash
 mads source -i in0_01 arduino.plugin
 ```
 
-Now you want turn this command into a service. Just put `mads service <service_name` in forn t of that command line, e.g.:
+Now you want turn this command into a service. Just put `mads service <service_name>` in front of that command line, e.g.:
 
 ```bash
 mads service arduino source -i in0_01 arduino.plugin

--- a/guides/zeroconf.qmd
+++ b/guides/zeroconf.qmd
@@ -44,7 +44,7 @@ sudo apt update && sudo apt install avahi-utils avahi-daemon openssh-server
 
 ## Configure the service
 
-Create a file named `/stc/avahi/services/ssh.service` with the following content:
+Create a file named `/etc/avahi/services/ssh.service` with the following content:
 
 ```xml
 <!-- See avahi.service(5) for more information about this configuration file -->


### PR DESCRIPTION
Corrected several typographical errors and improved clarity in the python_agent, services, and zeroconf guides. Fixed option flag references, directory paths, and command examples to ensure accuracy and better guidance for users.